### PR TITLE
Use DLockService to avoid concurrency errors.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/redis/internal/AutoCloseableLock.java
+++ b/geode-core/src/main/java/org/apache/geode/redis/internal/AutoCloseableLock.java
@@ -1,0 +1,22 @@
+package org.apache.geode.redis.internal;
+
+import org.apache.geode.cache.Region;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * Created by gosullivan on 3/10/17.
+ */
+public class AutoCloseableLock implements AutoCloseable {
+  Runnable unlock;
+
+  public AutoCloseableLock(Runnable unlockFunction) {
+    unlock = unlockFunction;
+  }
+
+  @Override
+  public void close() {
+    this.unlock.run();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/redis/internal/executor/hash/HIncrByExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/redis/internal/executor/hash/HIncrByExecutor.java
@@ -77,6 +77,7 @@ public class HIncrByExecutor extends HashExecutor {
 
     ByteArrayWrapper key = command.getKey();
 
+
     Map<ByteArrayWrapper, ByteArrayWrapper> map = getMap(context, key);
 
     byte[] byteField = commandElems.get(FIELD_INDEX);

--- a/geode-core/src/main/java/org/apache/geode/redis/internal/executor/hash/HMGetExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/redis/internal/executor/hash/HMGetExecutor.java
@@ -57,6 +57,7 @@ public class HMGetExecutor extends HashExecutor {
 
     ByteArrayWrapper key = command.getKey();
 
+
     Map<ByteArrayWrapper, ByteArrayWrapper> map = getMap(context, key);
 
     checkDataType(key, RedisDataType.REDIS_HASH, context);

--- a/geode-core/src/main/java/org/apache/geode/redis/internal/executor/set/SMembersExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/redis/internal/executor/set/SMembersExecutor.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.geode.cache.Region;
+import org.apache.geode.redis.internal.AutoCloseableLock;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
@@ -40,18 +41,21 @@ public class SMembersExecutor extends SetExecutor {
     ByteArrayWrapper key = command.getKey();
     checkDataType(key, RedisDataType.REDIS_SET, context);
 
-    Region<ByteArrayWrapper, Set<ByteArrayWrapper>> region = getRegion(context);
+    Set<ByteArrayWrapper> members;
+    try (AutoCloseableLock regionLock = withRegionLock(context, key)) {
+      Region<ByteArrayWrapper, Set<ByteArrayWrapper>> region = getRegion(context);
 
-    // companies:ea64fe8c-e0a0-4439-a05d-d0738dd5ef80:idx
-    Set<ByteArrayWrapper> set = region.get(key);
+      // companies:ea64fe8c-e0a0-4439-a05d-d0738dd5ef80:idx
+      Set<ByteArrayWrapper> set = region.get(key);
 
-    if (set == null) {
-      command.setResponse(Coder.getEmptyArrayResponse(context.getByteBufAllocator()));
-      return;
+      if (set == null) {
+        command.setResponse(Coder.getEmptyArrayResponse(context.getByteBufAllocator()));
+        return;
+      }
+
+      members = new HashSet<>(set); // Emulate copy on read
+
     }
-
-    Set<ByteArrayWrapper> members = new HashSet<ByteArrayWrapper>(set); // Emulate copy on read
-
     command.setResponse(Coder.getBulkStringArrayResponse(context.getByteBufAllocator(), members));
   }
 }


### PR DESCRIPTION
I'm not sure that this is the right way to do this, and it's still a WIP, but I wanted to run a benchmark that wasn't throwing concurrency errors all the time.